### PR TITLE
fix(Gui): Fix ImGui assers.

### DIFF
--- a/includes/gui/object_spawner.lua
+++ b/includes/gui/object_spawner.lua
@@ -21,7 +21,6 @@ function objectSpawnerUI()
     end
     if os_switch == 0 then
       displayFilteredProps()
-      ImGui.PopItemWidth()
     else
       getAllObjects()
     end

--- a/includes/gui/yrv2.lua
+++ b/includes/gui/yrv2.lua
@@ -998,7 +998,9 @@ function yrv2UI()
           end
           ImGui.EndDisabled()
         end
+        ImGui.EndTabItem()
       end
+      ImGui.EndTabBar()
     else
       ImGui.Dummy(1, 5); ImGui.SameLine(); ImGui.Text("Outdated.")
     end

--- a/includes/lib/samurais_utils.lua
+++ b/includes/lib/samurais_utils.lua
@@ -2269,7 +2269,6 @@ SS.set_hotkey = function(keybind)
 end
 
 SS.openHotkeyWindow = function(window_name, keybind)
-  ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, 10)
   ImGui.BulletText(window_name)
   local avail_x, _ = ImGui.GetContentRegionAvail()
   ImGui.SameLine(avail_x / 1.7)
@@ -2295,7 +2294,6 @@ SS.openHotkeyWindow = function(window_name, keybind)
     SS.set_hotkey(keybind)
     ImGui.End()
   end
-  ImGui.PopStyleVar(1)
 end
 
 ---@param keybind table
@@ -2350,7 +2348,6 @@ end
 ---@param window_name string
 ---@param keybind table
 SS.gpadHotkeyWindow = function(window_name, keybind)
-  ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, 10)
   ImGui.BulletText(window_name)
   local avail_x, _ = ImGui.GetContentRegionAvail()
   ImGui.SameLine(avail_x / 1.7)
@@ -2375,7 +2372,6 @@ SS.gpadHotkeyWindow = function(window_name, keybind)
     SS.set_gpad_hotkey(keybind)
     ImGui.End()
   end
-  ImGui.PopStyleVar(1)
 end
 
 -- Seamlessly add/remove keyboard keybinds on script update without requiring a config reset.


### PR DESCRIPTION
fix(View Object Spawner): Remove extra pop.

fix(SS.openHotkeyWindow): Remove broken style vars.
They were broken and didn't do anything, fixing them breaks things even more.

fix(YimResupplier): Add missing EndTab and EndTabBar.

###### Visual asserts in new ImGui versions are nice.