### PR TITLE
CI(release): move to schedules releases

### DIFF
--- a/.github/workflows/offsets.yml
+++ b/.github/workflows/offsets.yml
@@ -3,7 +3,7 @@ name: Update Offsets
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 4 * * 0'
+    - cron: '0 2 * * 6'
 
 
 concurrency:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,42 @@
+name: Generate Translations
+
+on:
+  push:
+    paths:
+      - "scripts/translations/**"
+      - "includes/lib/translations/en-US.lua"
+      - "includes/lib/translations/__locales.lua"
+  workflow_dispatch:
+
+concurrency:
+  group: ss_translations-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12.x"
+
+    - name: Run Generator
+      run: |
+        cd ./scripts/translations
+        python generate_translations.py
+
+    - name: Commit Changes
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add includes/lib/translations/
+        git add scripts/translations/hashmap.json || true
+        git diff --cached --quiet || git commit -m "feat(Translations): update translations"
+        git push

--- a/.github/workflows/zip-release.yml
+++ b/.github/workflows/zip-release.yml
@@ -1,12 +1,8 @@
-name: CI
+name: Zip Release
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "**/*.lua"
-      - "scripts/translations/**"
+  schedule:
+    - cron: '0 8 * * 0'
   workflow_dispatch:
 
 concurrency:
@@ -14,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  orchestrator:
+  release:
     name: CI Main
     runs-on: ubuntu-latest
     if: "! contains(github.event.head_commit.message, '[noci]')"
@@ -26,39 +22,42 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-
-    - name: Check Translations
-      id: check_translations
-      run: |
-        if git diff --name-only HEAD^ HEAD | grep -E 'scripts/translations/|hashmap.json|includes/lib/translations/__locales.lua|includes/lib/translations/en-US.lua'; then
-          echo "changed=true" >> $GITHUB_OUTPUT
-        else
-          echo "changed=false" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Setup Python
-      if: steps.check_translations.outputs.changed == 'true'
-      uses: actions/setup-python@v5
+    
+    - name: Check Changes
+      id: check_changes
+      uses: actions/github-script@v7
       with:
-        python-version: "3.12.x"
+        script: |
+          if (context.eventName === "workflow_dispatch") {
+            core.setOutput("should_proceed", "true");
+            return;
+          }
 
-    - name: Generate Translations
-      if: steps.check_translations.outputs.changed == 'true'
-      run: |
-        cd ./scripts/translations
-        python generate_translations.py
+          const { owner, repo } = context.repo;
+          const tags = await github.rest.repos.listTags({ owner, repo });
+          if (tags.data.length === 0) {
+            core.setOutput("should_proceed", "true");
+            return;
+          }
 
-    - name: Add Translations
-      id: commit_translations
-      if: steps.check_translations.outputs.changed == 'true'
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add includes/lib/translations/
-        git add scripts/translations/hashmap.json || true
+          const lastTag = tags.data[0].name;
+          const compare = await github.rest.repos.compareCommits({
+            owner,
+            repo,
+            base: lastTag,
+            head: "HEAD"
+          });
+
+          const files = compare.data.files || [];
+          const luaFiles = files.filter(f => f.filename.endsWith(".lua"));
+          core.setOutput(
+            "should_proceed",
+            luaFiles.length != 0 ? "true" : "false"
+          );
 
     - name: Increment Tag
       id: increment_tag
+      if: steps.check_changes.outputs.should_proceed == 'true'
       uses: actions/github-script@v7
       with:
         script: |
@@ -90,31 +89,98 @@ jobs:
           core.setOutput("version_number", new_tag);
           core.setOutput("no_prefix", no_prefix);
           core.setOutput("old_tag", old_tag);
+    
+    - name: Generate Changelog
+      id: changelog
+      if: steps.check_changes.outputs.should_proceed == 'true'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { owner, repo } = context.repo;
+          const lastTag = "${{ steps.increment_tag.outputs.old_tag }}";
+          const { data: tagRefs } = await github.rest.git.getRef({ owner, repo, ref: `tags/${lastTag}` });
+          const tagSha = tagRefs.object.sha;
+          const { data: tagCommit } = await github.rest.repos.getCommit({ owner, repo, ref: tagSha });
+          const lastTagDate = new Date(tagCommit.commit.committer.date);
+          const { data: pulls } = await github.rest.pulls.list({
+            owner, repo, state: "closed", sort: "updated", direction: "asc", per_page: 100
+          });
+
+          let changelog = "";
+
+          const mergedPRs = pulls.filter(pr => pr.merged_at && new Date(pr.merged_at) > lastTagDate);
+          const extractField = (body, fieldName) => {
+            const regex = new RegExp(`${fieldName}:\\s*([\\s\\S]*?)(?=\\n\\w+:|$)`, 'm');
+            const match = body.match(regex);
+            if (!match)
+              return "";
+
+            return match[1].trim();
+          };
+
+          if (mergedPRs.length > 0) {
+            for (const pr of mergedPRs) {
+              changelog += `## PR #${pr.number}: ${pr.title}\n`;
+              const body = pr.body
+              if (body) {
+                const lines = body.split('\n').map(line => line.trim().replace(/^-\s*/, ''));
+                for (const line of lines) {
+                  if (line)
+                    changelog += `- ${line}\n`;
+                }
+                changelog += "\n";
+              }
+            }
+          } else {
+            const compared = await github.rest.repos.compareCommits({
+              owner,
+              repo,
+              base: lastTag,
+              head: "main"
+            });
+
+            const commits = compared.data.commits;
+            for (const commit of commits) {
+              const msg = commit.commit.message;
+              const body = commit.commit.body;
+              if (msg.toLowerCase().startsWith("merge pull"))
+                continue;
+
+              changelog += `## ${msg}\n\n`;
+              if (body)
+                changelog += `${body}\n\n`;
+            }
+          }
+
+          core.setOutput("changelog", changelog);
 
     - name: Bump Version
+      if: steps.check_changes.outputs.should_proceed == 'true'
       run: |
         sed -i "s|return \".*\"|return \"${{steps.increment_tag.outputs.no_prefix}}\"|" includes/version.lua
         sed -i "s|https://img.shields.io/badge/Script%20Version-v[0-9]\+\.[0-9]\+\.[0-9]\+-blue|https://img.shields.io/badge/Script%20Version-${{steps.increment_tag.outputs.version_number}}-blue|g" README.md
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
         git add includes/version.lua README.md
         git diff --cached --quiet || git commit -m "[noci] bump version"
         git push
 
     - name: Create Archive
+      if: steps.check_changes.outputs.should_proceed == 'true'
       uses: thedoctor0/zip-release@0.7.6
       with:
         type: 'zip'
-        filename: "Samurais_Scripts_${{steps.increment_tag.outputs.version_number}}.zip"
+        filename: "Samurais_Scripts_${{ steps.increment_tag.outputs.version_number }}.zip"
         exclusions: /.git* /scripts* /docs* *.json *.md *.editorconfig *.py
 
     - name: Upload Release
+      if: steps.check_changes.outputs.should_proceed == 'true'
       uses: softprops/action-gh-release@v2
       with:
-        name: Samurai's Scripts ${{steps.increment_tag.outputs.version_number}}
-        tag_name: ${{steps.increment_tag.outputs.version_number}}
+        name: Samurai's Scripts ${{ steps.increment_tag.outputs.version_number }}
+        tag_name: ${{ steps.increment_tag.outputs.version_number }}
         body: |
           ### ${{steps.increment_tag.outputs.version_number}} Changelog
-          ${{ env.changelog_body }}
+          ${{ steps.changelog.outputs.changelog }}
         files: |
-          Samurais_Scripts_${{steps.increment_tag.outputs.version_number}}.zip
+          Samurais_Scripts_${{ steps.increment_tag.outputs.version_number }}.zip


### PR DESCRIPTION
- Zip Release:
  - Do not skip workflow dispatch.
  - Fix missing changelog parsing step.
  - Schedule releases once a week instead of on push. This allows us to introduce and/or revert changes without worrying about triggering releases.

- Translations:
  - Revert independent workflow. Let it run on push since it will no longer collide with the release workflow.

- Offset Updater:
  - Move schedule to Saturday at 2AM.